### PR TITLE
Make number of cases in `quickcheck` variants configurable

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -9,6 +9,11 @@
          (struct-out generator)
          (struct-out config)
          
+         with-test-count
+         with-small-test-count
+         with-medium-test-count
+         with-large-test-count
+         
          choose-integer choose-real
          choose-ascii-char choose-ascii-letter choose-printable-ascii-char choose-char
          choose-list choose-vector choose-string choose-symbol

--- a/scribblings/quickcheck.scrbl
+++ b/scribblings/quickcheck.scrbl
@@ -147,6 +147,54 @@ Testing the property reveals that it holds up:
   number. The @racket[print-every] field should be a function that
   takes the test number and the generated arguments and is called for
   its side effect.
+
+  The @racket[quickcheck] and @racket[quickcheck-results] functions use
+  a default config where the test count is @racket[100], the test size
+  for test @racket[n] is @racket[(+ 3 (quotient n 2))], the max fail
+  count is ten times the test count, and nothing is printed. The default
+  config can be adjusted to run different numbers of tests with
+  @racket[with-small-test-count], @racket[with-medium-test-count], and
+  @racket[with-large-test-count].
+}
+
+@defform[(with-small-test-count body ...)]{
+  Within @racket[body ...], the number of test cases used by the
+  @racket[quickcheck] functions is @racket[100].
+  @examples[#:eval qc-eval
+    (with-small-test-count
+      (quickcheck (property ((str arbitrary-string))
+                    (string=? str (list->string (string->list str))))))
+  ]
+}
+
+@defform[(with-medium-test-count body ...)]{
+  Within @racket[body ...], the number of test cases used by the
+  @racket[quickcheck] functions is @racket[1000].
+  @examples[#:eval qc-eval
+    (with-medium-test-count
+      (quickcheck (property ((str arbitrary-string))
+                    (string=? str (list->string (string->list str))))))
+  ]
+}
+
+@defform[(with-large-test-count body ...)]{
+  Within @racket[body ...], the number of test cases used by the
+  @racket[quickcheck] functions is @racket[10000].
+  @examples[#:eval qc-eval
+    (with-large-test-count
+      (quickcheck (property ((str arbitrary-string))
+                    (string=? str (list->string (string->list str))))))
+  ]
+}
+
+@defform[(with-test-count test-count-expr body ...)]{
+  Within @racket[body ...], the number of test cases used by teh
+  @racket[quickcheck] functions is @racket[test-count-expr].
+  @examples[#:eval qc-eval
+    (with-test-count 42
+      (quickcheck (property ((str arbitrary-string))
+                    (string=? str (list->string (string->list str))))))
+  ]
 }
 
 @defstruct[result ([ok (or/c null #t #f)]


### PR DESCRIPTION
This PR adds a parameter that can be used to tweak the number of cases `quickcheck` variants run. Most of the time when someone wants to provide a custom config, it's solely to increase the number of cases to run. The current defaults for max-fail-cases and the size function are not documented, so it's not clear what to use there when all you care about is the case count.

This doesn't directly expose the parameter, instead it provides a `with-test-count` sugar form and `with-small-test-count`, `with-medium-test-count`, and `with-large-test-count` sugar forms that run 100, 1000, and 10000 cases respectively.

In addition to making configuration simpler, it makes the configuration externally adjustable. For instance, given a module `m.rkt` that runs some `quickcheck` tests, another module can use `dynamic-require` to adjust the number of tests:

```
(require quichcheck)
(with-large-test-count
  (dynamic-require "m.rkt" #f))
```
 This opens up the possibility for a command line "raco quichcheck" tool that can adjust the test configuration differently in different environments or in response to command line flags, e.g. `raco quickcheck --large`.