### PR TITLE
Add raco command

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,12 @@
-#lang setup/infotab
+#lang info
 
 (define blurb '("DeinProgramm - QuickCheck"))
 (define primary-file "main.rkt")
 (define deps '("base" "rackunit"))
 (define build-deps '("scribble-lib" "racket-doc"))
 (define scribblings '(("scribblings/quickcheck.scrbl")))
+(define raco-commands
+  '(("quickcheck"
+     quickcheck/raco-quickcheck
+     "autogenerate property test cases"
+     25)))

--- a/main.rkt
+++ b/main.rkt
@@ -9,6 +9,11 @@
          (struct-out generator)
          (struct-out config)
          
+         with-test-count
+         with-small-test-count
+         with-medium-test-count
+         with-large-test-count
+         
          choose-integer choose-real
          choose-ascii-char choose-ascii-letter choose-printable-ascii-char choose-char
          choose-list choose-vector choose-string choose-symbol

--- a/raco-quickcheck.rkt
+++ b/raco-quickcheck.rkt
@@ -1,0 +1,46 @@
+#lang racket/base
+
+(require racket/bool
+         racket/cmdline
+         raco/command-name
+         "testing.rkt")
+
+
+(define (run-tests-small module-path)
+  (with-small-test-count
+    (dynamic-require module-path #f)))
+
+(define (run-tests-medium module-path)
+  (with-medium-test-count
+    (dynamic-require module-path #f)))
+
+(define (run-tests-large module-path)
+  (with-large-test-count
+    (dynamic-require module-path #f)))
+
+(define (run-tests n module-path)
+  (with-test-count n
+                   (dynamic-require module-path #f)))
+
+(define (read-command-line)
+  (define current-test-function (make-parameter run-tests))
+  (define current-num-tests (make-parameter #f))
+  (command-line
+   #:program (short-program+command-name)
+   #:once-any
+   [("-s" "--small") "Run a small number of test cases"
+                     (current-test-function run-tests-small)]
+   [("-m" "--medium") "Run a medium number of test cases"
+                      (current-test-function run-tests-medium)]
+   [("-l" "--large") "Run a large number of test cases"
+                     (current-test-function run-tests-large)]
+   [("-n" "--number") n "Run <n> test cases"
+                      (current-num-tests n)]
+   #:args module-path
+   (define (test-module-path a-module-path)
+     (if (false? (current-num-tests))
+         ((current-test-function) a-module-path)
+         ((current-test-function) (current-num-tests) a-module-path)))
+   (for-each test-module-path module-path)))
+
+(read-command-line)

--- a/scribblings/quickcheck.scrbl
+++ b/scribblings/quickcheck.scrbl
@@ -147,6 +147,54 @@ Testing the property reveals that it holds up:
   number. The @racket[print-every] field should be a function that
   takes the test number and the generated arguments and is called for
   its side effect.
+
+  The @racket[quickcheck] and @racket[quickcheck-results] functions use
+  a default config where the test count is @racket[100], the test size
+  for test @racket[n] is @racket[(+ 3 (quotient n 2))], the max fail
+  count is ten times the test count, and nothing is printed. The default
+  config can be adjusted to run different numbers of tests with
+  @racket[with-small-test-count], @racket[with-medium-test-count], and
+  @racket[with-large-test-count].
+}
+
+@defform[(with-small-test-count body ...)]{
+  Within @racket[body ...], the number of test cases used by the
+  @racket[quickcheck] functions is @racket[100].
+  @examples[#:eval qc-eval
+    (with-small-test-count
+      (quickcheck (property ((str arbitrary-string))
+                    (string=? str (list->string (string->list str))))))
+  ]
+}
+
+@defform[(with-medium-test-count body ...)]{
+  Within @racket[body ...], the number of test cases used by the
+  @racket[quickcheck] functions is @racket[1000].
+  @examples[#:eval qc-eval
+    (with-medium-test-count
+      (quickcheck (property ((str arbitrary-string))
+                    (string=? str (list->string (string->list str))))))
+  ]
+}
+
+@defform[(with-large-test-count body ...)]{
+  Within @racket[body ...], the number of test cases used by the
+  @racket[quickcheck] functions is @racket[10000].
+  @examples[#:eval qc-eval
+    (with-large-test-count
+      (quickcheck (property ((str arbitrary-string))
+                    (string=? str (list->string (string->list str))))))
+  ]
+}
+
+@defform[(with-test-count test-count-expr body ...)]{
+  Within @racket[body ...], the number of test cases used by teh
+  @racket[quickcheck] functions is @racket[test-count-expr].
+  @examples[#:eval qc-eval
+    (with-test-count 42
+      (quickcheck (property ((str arbitrary-string))
+                    (string=? str (list->string (string->list str))))))
+  ]
 }
 
 @defstruct[result ([ok (or/c null #t #f)]


### PR DESCRIPTION
This PR builds on top of #13 to add a simple `raco quickcheck` command for running quickcheck tests. The command uses the configuration parameter in #13 to make the number of tests adjustable from the command line. The following command:

```
raco quickcheck --large some-module.rkt
```

will run all quickcheck tests in `"./some-module.rkt"` with 10000 cases. The command also supports specifying an exact number of cases to run:

```
raco quickcheck --number 42 some-module.rkt
```

This runs 42 cases. The command additionally accepts an arbitrary number of modules, and runs commands on each of them:

```
raco quickcheck --medium some-module.rkt some-other-module.rkt yet-another-module.rkt
```

Immediate further work involves allowing the command to test everything in a directory, to test things matching a regexp, and to read a package's `info.rkt` and look for `test-omit-paths` and exclude those files from testing.

This PR contains the commit from #13, but if #13 is merged merging this will have no conflict.

TODO: Add docs