### PR TITLE
Add simple test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ install:
 
 script:
  - raco test $TRAVIS_BUILD_DIR
+ - raco quickcheck $TRAVIS_BUILD_DIR/quickcheck/private/test/main.rkt

--- a/info.rkt
+++ b/info.rkt
@@ -7,5 +7,6 @@
 (define deps '("base"
                "rackunit"))
 
-(define build-deps '("scribble-lib"
+(define build-deps '("doc-coverage"
+                     "scribble-lib"
                      "racket-doc"))

--- a/quickcheck/arbitrary.rkt
+++ b/quickcheck/arbitrary.rkt
@@ -15,12 +15,12 @@
          racket/promise)
 
 (define arbitrary-boolean
-  (make-arbitrary (choose-one-of '(#t #f))
+  (arbitrary (choose-one-of '(#t #f))
 		  (lambda (a gen)
 		    (variant (if a 0 1) gen))))
 
 (define arbitrary-integer
-  (make-arbitrary (sized
+  (arbitrary (sized
 		   (lambda (n)
 		     (choose-integer (- n) n)))
 		  (lambda (n gen)
@@ -30,29 +30,29 @@
 			     gen))))
 
 (define arbitrary-natural
-  (make-arbitrary (sized
+  (arbitrary (sized
 		   (lambda (n)
 		     (choose-integer 0 n)))
 		  (lambda (n gen)
 		    (variant n gen))))
 
 (define arbitrary-ascii-char
-  (make-arbitrary choose-ascii-char
+  (arbitrary choose-ascii-char
 		  (lambda (ch gen)
 		    (variant (char->integer ch) gen))))
 
 (define arbitrary-ascii-letter
-  (make-arbitrary choose-ascii-letter
+  (arbitrary choose-ascii-letter
 		  (lambda (ch gen)
 		    (variant (char->integer ch) gen))))
 
 (define arbitrary-printable-ascii-char
-  (make-arbitrary choose-printable-ascii-char
+  (arbitrary choose-printable-ascii-char
 		  (lambda (ch gen)
 		    (variant (char->integer ch) gen))))
 
 (define arbitrary-char
-  (make-arbitrary (sized
+  (arbitrary (sized
 		   (lambda (n)
 		     (choose-char (integer->char 0)
 				  (integer->char n))))
@@ -64,7 +64,7 @@
      (+ 1 b)))
 
 (define arbitrary-rational
-  (make-arbitrary (lift->generator make-rational
+  (arbitrary (lift->generator make-rational
 				   (arbitrary-generator arbitrary-integer)
 				   (arbitrary-generator arbitrary-natural))
 		  (lambda (r gen)
@@ -79,7 +79,7 @@
 			(+ (abs c) 1)))))
 
 (define arbitrary-real
-  (make-arbitrary (lift->generator fraction
+  (arbitrary (lift->generator fraction
 				   (arbitrary-generator arbitrary-integer)
 				   (arbitrary-generator arbitrary-integer)
 				   (arbitrary-generator arbitrary-integer))
@@ -92,7 +92,7 @@
 
 
 (define (arbitrary-mixed pred+arbitrary-promise-list)
-  (make-arbitrary (choose-mixed (map (lambda (p)
+  (arbitrary (choose-mixed (map (lambda (p)
 				       (delay (arbitrary-generator (force (cdr p)))))
 				     pred+arbitrary-promise-list))
 		  (lambda (val gen)
@@ -108,7 +108,7 @@
 			(loop (cdr lis) (+ 1 n))))))))
 
 (define (arbitrary-one-of eql? . vals)
-  (make-arbitrary (choose-one-of vals)
+  (arbitrary (choose-one-of vals)
 		  (lambda (val gen)
 		    (let loop ((lis vals) (n 0))
 		      (cond
@@ -122,7 +122,7 @@
 			(loop (cdr lis) (+ 1 n))))))))
 		       
 (define (arbitrary-pair arbitrary-car arbitrary-cdr)
-  (make-arbitrary (lift->generator cons
+  (arbitrary (lift->generator cons
 				   (arbitrary-generator arbitrary-car)
 				   (arbitrary-generator arbitrary-cdr))
 		  (lambda (p gen)
@@ -133,7 +133,7 @@
 
 ; a tuple is just a non-uniform list 
 (define (arbitrary-tuple . arbitrary-els)
-  (make-arbitrary (apply lift->generator
+  (arbitrary (apply lift->generator
 			 list
 			 (map arbitrary-generator arbitrary-els))
 		  (lambda (lis gen)
@@ -147,7 +147,7 @@
 				  (cdr lis))))))))
 
 (define (arbitrary-record construct accessors . arbitrary-els)
-  (make-arbitrary (apply lift->generator
+  (arbitrary (apply lift->generator
 			 construct
 			 (map arbitrary-generator arbitrary-els))
 		  (lambda (rec gen)
@@ -161,7 +161,7 @@
 				  (cdr lis))))))))
 
 (define (arbitrary-sequence choose-sequence sequence->list arbitrary-el)
-  (make-arbitrary (sized
+  (arbitrary (sized
 		   (lambda (n)
 		     (>>= (choose-integer 0 n)
 			  (lambda (length)
@@ -197,7 +197,7 @@
 
 (define (arbitrary-procedure arbitrary-result . arbitrary-args)
   (let ((arbitrary-arg-tuple (apply arbitrary-tuple arbitrary-args)))
-    (make-arbitrary (promote
+    (arbitrary (promote
 		     (lambda args
 		       ((arbitrary-transformer arbitrary-arg-tuple)
 			args

--- a/quickcheck/info.rkt
+++ b/quickcheck/info.rkt
@@ -8,3 +8,6 @@
      quickcheck/raco-quickcheck
      "autogenerate property test cases"
      25)))
+
+(define test-omit-paths
+  '("scribblings"))

--- a/quickcheck/main.rkt
+++ b/quickcheck/main.rkt
@@ -1,10 +1,10 @@
 #lang racket/base
 
 (provide quickcheck quickcheck-results make-config
-         quickcheck/config quickcheck/config-results
          
          (struct-out result)
-         (struct-out arbitrary)
+         arbitrary?
+         arbitrary
          (struct-out generator)
          (struct-out config)
          
@@ -48,7 +48,3 @@
          "testing.rkt"
          "private/random.rkt"
          "private/error.rkt")
-
-(provide exn:assertion-violation?
-         exn:assertion-violation-who
-         exn:assertion-violation-irritants)

--- a/quickcheck/private/arbitrary.rkt
+++ b/quickcheck/private/arbitrary.rkt
@@ -5,7 +5,7 @@
 
 ;; generator   : (generator a)
 ;; transformer : a (generator b) -> (generator b)
-(define-struct arbitrary (generator transformer))
+(struct arbitrary (generator transformer))
 
 ; class Arbitrary a where
 ;    arbitrary   :: Gen a

--- a/quickcheck/private/test/doc-coverage.rkt
+++ b/quickcheck/private/test/doc-coverage.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+
+(module+ test
+  (require doc-coverage
+           quickcheck
+           rackunit/quickcheck)
+  (check-all-documented 'quickcheck)
+  (check-all-documented 'rackunit/quickcheck))

--- a/quickcheck/private/test/main.rkt
+++ b/quickcheck/private/test/main.rkt
@@ -1,0 +1,11 @@
+#lang racket/base
+
+(module+ property-test
+  (require quickcheck
+           rackunit/quickcheck)
+  (define (involutes? f v) (equal? (f (f v)) v))
+  (define reverse-involution?
+    (property ([vs (arbitrary-list arbitrary-natural)])
+      (involutes? reverse vs)))
+  (quickcheck reverse-involution?)
+  (check-property reverse-involution?))

--- a/quickcheck/scribblings/quickcheck.scrbl
+++ b/quickcheck/scribblings/quickcheck.scrbl
@@ -201,13 +201,13 @@ Testing the property reveals that it holds up:
 
 @defstruct[result ([ok (or/c null #t #f)]
                    [stamp (listof string?)]
-                   [argument-list (listof any/c)])]{
+                   [arguments-list (listof any/c)])]{
   Represents a single result from a test. The @racket[ok] field is
   @racket[#t] on success, @racket[#f] on failure, and @racket[null] if
   there is no test result.
 
   The @racket[stamp] field represents the labels that were relevant to
-  this test execution. The @racket[argument-list] is a list of the
+  this test execution. The @racket[arguments-list] is a list of the
   values generated for checking this test case.
 }
 
@@ -411,10 +411,14 @@ Crucially, every time the property is tested with a different set of arguments
   given an integer representing a value's size.
 }
 
-@defstruct[arbitrary ([gen generator?] [trans (-> any/c generator? generator?)])]{
-  Represents a source of randomly generated values, except where the values
-  are filtered by the function @racket[trans] to produce a narrower set of
-  new values.
+@defthing[arbitrary? predicate/c]{Recognizes @racket[arbitrary]s.}
+
+@defproc[(arbitrary [gen generator?]
+                    [trans (-> any/c generator? generator?)])
+         arbitrary?]{
+  Returns a source of randomly generated values, except where the values
+  are filtered by the function @racket[trans] to produce a narrower set
+  of new values.
 }
 
 @defthing[arbitrary-boolean arbitrary?]{


### PR DESCRIPTION
This tests the following:

1. That all exports from `(require quickcheck)` and `(require
rackunit/quickcheck)` are documented
2. That the `raco quickcheck` command works by default and picks up a
`property-test` submodule
3. That a property can be created
4. That that property passes both the `quickcheck` and `check-results`
testing functions.

Additionally, a few surface changes are made to the API:

1. The documentation on `arbitrary` is limited now to only provide a predicate and a means of creating them, rather than documenting that they're structs (the fields were misnamed anyway so this would be broken for clients depending on that behavior).
2. The `result` struct's documentation was corrected to fix a field naming issue
3. The exception types were removed from the provided API, as they were undocumented.
4. The `raco quickcheck` command defaults to a small test size when not given any flags
5. The `raco quickcheck` command now operates like `raco test` and looks for a `property-test` submodule to run. If none is present, it simply runs the file normally.