### PR TITLE
Provide variant

### DIFF
--- a/quickcheck/main.rkt
+++ b/quickcheck/main.rkt
@@ -39,6 +39,7 @@
          trivial
          collect
          testable?
+         variant
          )
 
 (require "arbitrary.rkt"


### PR DESCRIPTION
I think we need to provide `variant` to allow others to define their custom `arbitrary` values. Following the example of the definition of `arbitrary-natural`, here's the definition of `arbitrary/64` which generates arbitrary 64bit values:
```racket
(define arbitrary/64
  (arbitrary (sized (lambda (n) (choose-integer 0 (- (expt 2 64) 1))))
                 (lambda (n gen) (variant n gen))))
```

However, this is not possible if variant is not provided.