### PR TITLE
Take cdr of frequency list on pick recursion.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,35 @@
+dist: trusty
 language: c
 sudo: false
 env:
   global:
     - RACKET_DIR=~/racket
   matrix:
-    - RACKET_VERSION=6.1.1
-      VERSION_SPECIFIC_CATALOG="http://download.racket-lang.org/releases/6.1.1/catalog/"
-    - RACKET_VERSION=6.2
-      VERSION_SPECIFIC_CATALOG="http://download.racket-lang.org/releases/6.2/catalog/"
+    - RACKET_VERSION=6.3
+    - RACKET_VERSION=6.6
+    - RACKET_VERSION=6.9
+    - RACKET_VERSION=6.12
+    - RACKET_VERSION=7.0
+    - RACKET_VERSION=7.3
+    - RACKET_VERSION=7.4
+    - RACKET_VERSION=7.5
+    - RACKET_VERSION=7.6
     - RACKET_VERSION=HEAD
-      VERSION_SPECIFIC_CATALOG="http://download.racket-lang.org/releases/6.2/catalog/"
+    - RACKET_VERSION=HEADCS
+
+matrix:
+  allow-failures:
+    - env: RACKET_VERSION=HEAD
+    - env: RACKET_VERSION=HEADCS
+  fast_finish: true
 
 before_install:
-  - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket
-  - cat ../travis-racket/install-racket.sh | bash
+  - git clone https://github.com/greghendershott/travis-racket.git 
+  - cat travis-racket/install-racket.sh | bash
   - export PATH="${RACKET_DIR}/bin:${PATH}"
 
-install:
- - raco pkg config --set catalogs $VERSION_SPECIFIC_CATALOG http://pkgs.racket-lang.org http://planet-compats.racket-lang.org
- - raco pkg install --deps search-auto $TRAVIS_BUILD_DIR
-
 script:
- - raco test $TRAVIS_BUILD_DIR
- - raco quickcheck $TRAVIS_BUILD_DIR/quickcheck/private/test/main.rkt
+ - cd ..
+ - travis_retry raco pkg install --deps search_auto https://github.com/ausimian/racket-quickcheck.git
+ - raco test quickcheck
+ - raco quickcheck quickcheck/private/test/main.rkt

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,4 @@ before_install:
 script:
  - cd ..
  - travis_retry raco pkg install --deps search-auto https://github.com/ausimian/racket-quickcheck.git
- - raco test quickcheck
- - raco quickcheck quickcheck/private/test/main.rkt
+ - raco test -p quickcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ before_install:
 
 script:
  - cd ..
- - travis_retry raco pkg install --deps search_auto https://github.com/ausimian/racket-quickcheck.git
+ - travis_retry raco pkg install --deps search-auto https://github.com/ausimian/racket-quickcheck.git
  - raco test quickcheck
  - raco quickcheck quickcheck/private/test/main.rkt

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ before_install:
 script:
  - cd ..
  - travis_retry raco pkg install --deps search-auto https://github.com/ausimian/racket-quickcheck.git
- - raco test -p quickcheck
+ - raco test -p racket-quickcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,6 @@ before_install:
 
 script:
  - cd ..
- - travis_retry raco pkg install --deps search-auto https://github.com/ausimian/racket-quickcheck.git
+ - travis_retry raco pkg install --deps search-auto --clone racket-quickcheck https://github.com/ausimian/racket-quickcheck.git
  - raco test -p racket-quickcheck
+ - raco quickcheck racket-quickcheck/quickcheck/private/test/main.rkt

--- a/quickcheck/generator.rkt
+++ b/quickcheck/generator.rkt
@@ -147,7 +147,7 @@
   (let ((k (caar lis)))
     (if (<= n k)
 	(cdar lis)
-	(pick (- n k) lis))))
+	(pick (- n k) (cdr lis)))))
 
 (define-syntax (bind-generators stx)
   (syntax-parse stx

--- a/quickcheck/scribblings/quickcheck.scrbl
+++ b/quickcheck/scribblings/quickcheck.scrbl
@@ -304,6 +304,10 @@ property:
 ]
 }
 
+@defform[(check-property/quiet prop)]{
+Similar to @racket[check-property] but doesn't produce output.
+}
+
 @defform[(check-property/config config prop)]{
 Similar to @racket[check-property] but taking a specific @racket[config] object.
 }


### PR DESCRIPTION
The choose-with-frequencies function chooses a random int between
1 and the sum of all frequencies, and then calls pick which recurses
on the frequencies until the correct generator is found.

This commit fixes a bug where the cdr of the frequency list was not
actually passed in the recursive calls, causing a variety of bugs
ranging from always the selecting the first, to never terminating.