### PR TITLE
fix choose-with-frequencies only choosing first option

### DIFF
--- a/quickcheck/generator.rkt
+++ b/quickcheck/generator.rkt
@@ -147,7 +147,7 @@
   (let ((k (caar lis)))
     (if (<= n k)
 	(cdar lis)
-	(pick (- n k) lis))))
+	(pick (- n k) (cdr lis)))))
 
 (define-syntax (bind-generators stx)
   (syntax-parse stx


### PR DESCRIPTION
# Problem

`choose-with-frequencies` only every chooses the first option of the list of _weighted generators_.
The problem is in the auxilliary function `pick`.

![Screen Shot 2020-07-10 at 23 29 37](https://user-images.githubusercontent.com/3605049/87208392-79dd7c80-c306-11ea-8ebd-4593586c29fc.png)

# Solution

Fix `pick` by recursing with the `cdr` of the list of _weighted generators_.

![Screen Shot 2020-07-10 at 23 33 07](https://user-images.githubusercontent.com/3605049/87208544-efe1e380-c306-11ea-8ca9-2f9cd0296b61.png)

# Note

I found out that another person found and fixed this bug after I had already created the PR, oops.
