### PR TITLE
Make bind-generators consistently lazy

### DIFF
--- a/quickcheck/generator.rkt
+++ b/quickcheck/generator.rkt
@@ -154,11 +154,10 @@
     [(_ ([id:id val-expr:expr]
          [id-rest:id val-expr-rest:expr] ...)
         body:expr)
-     (let ([recurse #'(bind-generators ([id-rest val-expr-rest] ...)
-                                       body)])
-       #`(let ([id val-expr])
-           (if (generator? id)
-               (>>= id (λ(id) #,recurse))
-               #,recurse)))]
+     #`(let* ([id val-expr]
+              [gen (if (generator? id) id (generator-unit id))])
+         (>>= gen (λ (id) (bind-generators
+                           ([id-rest val-expr-rest] ...)
+                           body))))]
     [(_ () body:expr)
      #'(return body)]))

--- a/quickcheck/generator.rkt
+++ b/quickcheck/generator.rkt
@@ -149,15 +149,26 @@
 	(cdar lis)
 	(pick (- n k) (cdr lis)))))
 
-(define-syntax (bind-generators stx)
+(define-syntax (bind-generators-recurse stx)
   (syntax-parse stx
     [(_ ([id:id val-expr:expr]
          [id-rest:id val-expr-rest:expr] ...)
         body:expr)
      #`(let* ([id val-expr]
               [gen (if (generator? id) id (generator-unit id))])
-         (>>= gen (λ (id) (bind-generators
+         (>>= gen (λ (id) (bind-generators-recurse
                            ([id-rest val-expr-rest] ...)
                            body))))]
     [(_ () body:expr)
      #'(return body)]))
+
+(define-syntax (bind-generators stx)
+  (syntax-parse stx
+    [(_ ([id:id val-expr:expr] ...)
+        body:expr)
+     #'(make-generator
+        (λ (size rgen)
+          ((generator-proc (bind-generators-recurse
+                            ([id val-expr] ...)
+                            body))
+           size rgen)))]))


### PR DESCRIPTION
Currently `bind-generators` isn't lazy on the first binding, and isn't lazy on the body if there are no bindings. This PR changes this to make `bind-generators` lazy in all cases. This does change the behavior from being exactly that of nested calls to `generator-bind`, but I think that it is less confusing to be consistently lazy in all cases.

This also fixes an exponential code duplication issue with `bind-generators` that I can split into a different pull request if the behavior change is undesired.