### PR TITLE
add documentation for check-property/quiet

### DIFF
--- a/quickcheck/scribblings/quickcheck.scrbl
+++ b/quickcheck/scribblings/quickcheck.scrbl
@@ -308,6 +308,10 @@ property:
 Similar to @racket[check-property] but taking a specific @racket[config] object.
 }
 
+@defform[(check-property/quiet prop)]{
+Like @racket[check-property] but suppresses any output generated during the run.
+}
+
 @defform[(add-property-check-info ((name value) ...))]{ Adds specific
 @racket[check-info] data when checking a property, using either
 @racket[check-property] or @racket[check-property/config]. Its usage is like


### PR DESCRIPTION
Currently, the test suite for this package fails because it checks whether all exported symbols are documented. However, the form `check-property/quiet` exported by `rackunit/quickcheck` has no documentation letting the build fail.

This pr provides a basic documentation for `check-property/quiet` making `racket-quickcheck` pass its test suite.