### PR TITLE
generator-unit is called return internally

### DIFF
--- a/quickcheck/generator.rkt
+++ b/quickcheck/generator.rkt
@@ -155,7 +155,7 @@
          [id-rest:id val-expr-rest:expr] ...)
         body:expr)
      #`(let* ([id val-expr]
-              [gen (if (generator? id) id (generator-unit id))])
+              [gen (if (generator? id) id (return id))])
          (>>= gen (λ (id) (bind-generators-recurse
                            ([id-rest val-expr-rest] ...)
                            body))))]


### PR DESCRIPTION
generator-unit is the external name for the function internally known as "return". the renaming is done in the re-exports in main