### PR TITLE
set license metadata and fix dependencies

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -10,3 +10,5 @@
 (define build-deps '("doc-coverage"
                      "scribble-lib"
                      "racket-doc"))
+
+(define license 'MIT)

--- a/info.rkt
+++ b/info.rkt
@@ -4,8 +4,7 @@
 
 (define version "0.1")
 
-(define deps '("base"
-               "rackunit"))
+(define deps '("base"))
 
 (define build-deps '("doc-coverage"
                      "scribble-lib"

--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 
 (define version "0.1")
 
-(define deps '("base"))
+(define deps '("base" "rackunit-lib"))
 
 (define build-deps '("doc-coverage"
                      "scribble-lib"


### PR DESCRIPTION
### License Metadata

#### Observation

The Racket package manager flags this repository as having missing license metadata.

https://pkgs.racket-lang.org/package/quickcheck

#### Execution

Add license information to `info.rkt`

### Fix Dependencies

#### Observation

Running a dependency check on the `quickcheck` package yields the following:

    raco setup --no-docs --check-pkg-deps --unused-pkg-deps quickcheck

    raco setup: unused dependencies detected
      for package: "quickcheck"
      on packages:
       "rackunit-gui"
       "rackunit-plugin-lib"
       "rackunit"
       "rackunit-doc"

#### Execution

Replace the run-time dependency on `rackunit` with `rackunit-lib`.


